### PR TITLE
Fixed using FXResourceBundleControl on named modules

### DIFF
--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -177,7 +177,20 @@ abstract class Component : Configurable {
         override fun get(): ResourceBundle? {
             if (super.get() == null) {
                 try {
-                    val bundle = ResourceBundle.getBundle(FX.messagesNameProvider(this@Component.javaClass), FX.locale, this@Component.javaClass.classLoader, FXResourceBundleControl)
+                    val bundle = if (this@Component.javaClass.module.isNamed) {
+                        ResourceBundle.getBundle(
+                                FX.messagesNameProvider(this@Component.javaClass),
+                                FX.locale,
+                                this@Component.javaClass.module
+                        )
+                    } else {
+                        ResourceBundle.getBundle(
+                                FX.messagesNameProvider(this@Component.javaClass),
+                                FX.locale,
+                                this@Component.javaClass.classLoader,
+                                FXResourceBundleControl
+                        )
+                    }
                     (bundle as? FXPropertyResourceBundle)?.inheritFromGlobal()
                     set(bundle)
                 } catch (ex: Exception) {

--- a/src/main/java/tornadofx/FX.kt
+++ b/src/main/java/tornadofx/FX.kt
@@ -197,7 +197,22 @@ class FX {
          */
         private fun loadMessages() {
             val globalName = messagesNameProvider(null)
-            messages = runCatching { ResourceBundle.getBundle(globalName, locale, FXResourceBundleControl) }
+            val bundle = if (this::class.java.module.isNamed) {
+                ResourceBundle.getBundle(
+                        globalName,
+                        locale,
+                        this::class.java.module
+                )
+            } else {
+                ResourceBundle.getBundle(
+                        globalName,
+                        locale,
+                        this::class.java.classLoader,
+                        FXResourceBundleControl
+                )
+            }
+
+            messages = runCatching { bundle }
                     .onFailure { log.fine("No global '$globalName' found in locale $locale, using empty bundle") }
                     .getOrDefault(EmptyResourceBundle)
         }


### PR DESCRIPTION
FXResourceBundleControl is unavailable on named modules. This commit only changes behaviour on named modules to not use the ResourceBundle.Control.