### PR TITLE
Fixes FX.loadMessages & minor pom issues allowing tests to run successfully

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,7 @@
                     <argLine>
                         --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
                         --add-exports tornadofx/tornadofx.tests=kotlin.reflect
+                        --add-opens javafx.graphics/javafx.scene=tornadofx
                         --add-opens tornadofx/tornadofx.tests=javafx.base
                         --add-reads tornadofx=jdk.httpserver
                     </argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <reportNotDocumented>false</reportNotDocumented>
+<!--                    <reportNotDocumented>false</reportNotDocumented>-->
                     <skipEmptyPackages>true</skipEmptyPackages>
                     <jdkVersion>8</jdkVersion>
                     <impliedPlatforms>
@@ -246,6 +246,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven.jar.version}</version>
                 <configuration>

--- a/src/main/java/tornadofx/FX.kt
+++ b/src/main/java/tornadofx/FX.kt
@@ -197,22 +197,23 @@ class FX {
          */
         private fun loadMessages() {
             val globalName = messagesNameProvider(null)
-            val bundle = if (this::class.java.module.isNamed) {
-                ResourceBundle.getBundle(
+            val bundle: () -> ResourceBundle = {
+                if (this::class.java.module.isNamed) {
+                    ResourceBundle.getBundle(
                         globalName,
                         locale,
                         this::class.java.module
-                )
-            } else {
-                ResourceBundle.getBundle(
+                    )
+                } else {
+                    ResourceBundle.getBundle(
                         globalName,
                         locale,
                         this::class.java.classLoader,
                         FXResourceBundleControl
-                )
+                    )
+                }
             }
-
-            messages = runCatching { bundle }
+            messages = runCatching { bundle() }
                     .onFailure { log.fine("No global '$globalName' found in locale $locale, using empty bundle") }
                     .getOrDefault(EmptyResourceBundle)
         }


### PR DESCRIPTION
- Recent changes to FX.loadMessages caused a lot of tests to crash -> fixed this
- ValidationTest needs access to javafx.scene -> added corresponding --add-opens 
- missing group & unknown tag corrected. The last may depend on my maven/idea version.