### PR TITLE
BUGFIX: SmartTableCell styleclass ghosting

### DIFF
--- a/src/main/java/tornadofx/TableView.kt
+++ b/src/main/java/tornadofx/TableView.kt
@@ -40,6 +40,7 @@ open class SmartTableCell<S, T>(val scope: Scope = FX.defaultScope, val owningCo
     private val cellCache: TableColumnCellCache<T>? get() = owningColumn.properties["tornadofx.cellCache"] as TableColumnCellCache<T>?
     private var cellFragment: TableCellFragment<S, T>? = null
     private var fresh = true
+    private var freshStyleClass: Collection<String>? = null
 
     init {
         owningColumn.properties["tornadofx.cellFormatCapable"] = true
@@ -84,6 +85,7 @@ open class SmartTableCell<S, T>(val scope: Scope = FX.defaultScope, val owningCo
             if (fresh) {
                 val cellFragmentType = owningColumn.properties["tornadofx.cellFragment"] as KClass<TableCellFragment<S, T>>?
                 cellFragment = if (cellFragmentType != null) find(cellFragmentType, scope) else null
+                freshStyleClass = listOf(*styleClass.toTypedArray())
                 fresh = false
             }
             cellFragment?.apply {
@@ -103,8 +105,8 @@ open class SmartTableCell<S, T>(val scope: Scope = FX.defaultScope, val owningCo
         text = null
         graphic = null
         style = null
-        // Can't clear styleClass as this would mess with arrow icons for branches. We might improve this by keeping "cell", "indexed-cell" and "tree-cell" and remove the rest
-//        styleClass.clear()
+        //restore default style classes
+        freshStyleClass?.let { styleClass.retainAll(it) }
     }
 
     private fun clearCellFragment() {

--- a/src/test/kotlin/tornadofx/tests/TableViewTest.kt
+++ b/src/test/kotlin/tornadofx/tests/TableViewTest.kt
@@ -5,11 +5,17 @@ import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.collections.FXCollections
 import javafx.scene.Scene
+import javafx.scene.control.TableCell
+import javafx.scene.control.TableView
 import javafx.scene.layout.StackPane
 import javafx.stage.Stage
+import org.assertj.core.api.Assertions.*
 import org.junit.Test
+import org.testfx.api.FxAssert.*
 import org.testfx.api.FxRobot
+import org.testfx.api.FxService.serviceContext
 import org.testfx.api.FxToolkit
+import org.testfx.matcher.base.NodeMatchers.*
 import tornadofx.*
 import java.nio.file.Paths
 
@@ -46,4 +52,60 @@ class TableViewTest {
         val robot = FxRobot()
         robot.robotContext().captureSupport.saveImage(robot.capture(primaryStage.scene.root).image, Paths.get("example-table.png"))
     }
+
+    @Test
+    fun `SmartTableCell should reset styleClass for empty cells`() {
+        val testValue0 = SimpleIntegerProperty(0)
+        val testValue1 = SimpleIntegerProperty(1)
+        val list = FXCollections.observableArrayList(testValue0)
+
+        FxToolkit.setupFixture {
+            val root = StackPane().apply {
+                tableview(list) {
+                    column("Column A", Int::class) {
+                        value { it.value }
+                    }.cellFormat {
+                        text = it.toString()
+                        if (it == 0) {
+                            styleClass.remove("teststyle")
+                        } else {
+                            styleClass.add("teststyle")
+                        }
+                    }
+                }
+                setPrefSize(100.0, 150.0)
+            }
+            primaryStage.scene = Scene(root)
+            primaryStage.show()
+        }
+        //precheck
+        val table = serviceContext().nodeFinder.lookup(".table-view").query<TableView<Any>>()
+        verifyThat(table, isNotNull())
+
+        //given
+        assertThat(getCellsWithStyle(table, "teststyle")).isEmpty()
+
+        //change value
+        FxToolkit.setupFixture {
+            list.replaceAll { it?.let{testValue1}  }
+        }
+        //expect exactly one cell with teststyle
+        assertThat(getCellsWithStyle(table, "teststyle")).hasSize(1)
+
+        //change back
+        FxToolkit.setupFixture {
+            list.replaceAll { it?.let{testValue0}  }
+        }
+        //expect no cell with teststyle
+        assertThat(getCellsWithStyle(table, "teststyle"))
+            .`as`("empty cell should not have style 'teststyle' set")
+            .isEmpty()
+
+    }
+
+    private fun getCellsWithStyle(table: TableView<Any>?, styleClass: String) =
+        getAllCells(table).filter { it.styleClass.contains(styleClass) }.toList()
+
+    private fun getAllCells(table: TableView<Any>?) =
+        serviceContext().nodeFinder.from(table).lookup(".table-cell").queryAll<TableCell<Any, Any>>()
 }


### PR DESCRIPTION
SmartTableCell.updateItem() does not clear styleclass for empty cells - fixed (with unit test)

