### PR TITLE
Internal window overlay implementation

### DIFF
--- a/src/main/java/tornadofx/InternalWindow.kt
+++ b/src/main/java/tornadofx/InternalWindow.kt
@@ -4,15 +4,13 @@ import javafx.beans.property.SimpleStringProperty
 import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.Parent
-import javafx.scene.canvas.Canvas
 import javafx.scene.effect.DropShadow
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent
-import javafx.scene.layout.BorderPane
-import javafx.scene.layout.Region
-import javafx.scene.layout.StackPane
+import javafx.scene.layout.*
 import javafx.scene.paint.Color
 import javafx.scene.paint.Paint
+import javafx.scene.shape.Shape
 import tornadofx.InternalWindow.Styles.Companion.crossPath
 import java.awt.Toolkit
 import java.net.URL
@@ -23,7 +21,7 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
     private lateinit var view: UIComponent
     private var titleProperty = SimpleStringProperty()
     private var ownerPlacementInBorderPane: BorderPaneContainer? = null
-    var overlay: Canvas? = null
+    var overlay: Shape? = null
     private var indexInCoverParent: Int? = null
     private var coverParent: Parent? = null
     private var offsetX = 0.0
@@ -40,16 +38,14 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
         addClass(Styles.floatingWindowWrapper)
 
         if (modal) {
-            canvas {
+            rectangle {
                 overlay = this
-                graphicsContext2D.fill = overlayPaint
+                fill = overlayPaint
                 setOnMouseClicked {
                     Toolkit.getDefaultToolkit().beep()
                 }
                 widthProperty().bind(this@InternalWindow.widthProperty())
                 heightProperty().bind(this@InternalWindow.heightProperty())
-                widthProperty().onChange { fillOverlay() }
-                heightProperty().onChange { fillOverlay() }
             }
         }
 
@@ -135,14 +131,6 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
 
     override fun getUserAgentStylesheet(): String = URL("css://${Styles::class.java.name}").toExternalForm()
 
-    fun fillOverlay() {
-        overlay?.graphicsContext2D.apply {
-            val lb = coverNode.layoutBounds
-            this?.clearRect(0.0, 0.0, lb.width, lb.height)
-            this?.fillRect(0.0, 0.0, lb.width, lb.height)
-        }
-    }
-
     fun open(view: UIComponent, owner: Node) {
         if (owner.parent is InternalWindow) return
         this.view = view
@@ -173,7 +161,6 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
         (window.center as Parent) += view
 
         children.add(0, owner)
-        fillOverlay()
     }
 
     fun close() {

--- a/src/main/java/tornadofx/InternalWindow.kt
+++ b/src/main/java/tornadofx/InternalWindow.kt
@@ -64,7 +64,7 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
                     }
                     if (closeButton) {
                         button {
-                            addClass(Styles.closebutton)
+                            addClass(Styles.closeButton)
                             setOnMouseClicked {
                                 close()
                             }
@@ -90,7 +90,7 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
             val floatingWindowContent by cssclass()
             val window by cssclass()
             val top by cssclass()
-            val closebutton by cssclass()
+            val closeButton by cssclass()
             val crossPath = "M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"
         }
 
@@ -108,7 +108,7 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
 
                     alignment = Pos.CENTER
 
-                    closebutton {
+                    closeButton {
                         padding = box(4.px, 12.px)
                         backgroundRadius += box(0.px)
                         backgroundColor += Color.WHITE

--- a/src/main/java/tornadofx/InternalWindow.kt
+++ b/src/main/java/tornadofx/InternalWindow.kt
@@ -197,10 +197,10 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
 
             window.resizeRelocate(windowX, windowY, window.width, window.height)
         } else {
-            val windowWidth = Math.min(prefWidth, lb.width)
-            val windowHeight = Math.min(prefHeight, lb.height)
+            val windowWidth = prefWidth.coerceAtMost(lb.width)
+            val windowHeight = prefHeight.coerceAtMost(lb.height)
 
-            window.resizeRelocate(Math.max(0.0, x), Math.max(0.0, y), windowWidth, windowHeight)
+            window.resizeRelocate(0.0.coerceAtLeast(x), 0.0.coerceAtLeast(y), windowWidth, windowHeight)
 
         }
 


### PR DESCRIPTION

Fixes #27

Replaces the implementation of the Internal Window overlay from a Canvas based implementation to a Rectangle.

This PR also replaces some java Math functions with their kotlin equivalents and fixes a camelCase name.

