### PR TITLE
fix currentWindow keeping reference to old modalstage

### DIFF
--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -1076,6 +1076,9 @@ abstract class UIComponent(viewTitle: String? = "", icon: Node? = null) : Compon
                 setOnHidden {
                     modalStage = null
                     callOnUndock()
+                    /* reset scene so that next time time openModal is called the owner parameter
+                    does not return this modal stage */
+                    scene.root = Pane()
                 }
 
                 if (block) showAndWait() else show()


### PR DESCRIPTION
fix #31 

When openModal is called, the default parameter for `owner` is `currentWindow` which will look for a `Window` in the following order:

1. The components `modalStage`
2. The components `root.scene.window`
3. The `primaryStage`

The first time a modal window is opened the components `currentWindow` will return `primaryStage` and in the `openModal` function that component will have its root put into a newly built scene and that scene will become the scene of a newly made `modalStage`.

When the Modal Stage is closed the component has its modalstage set to null, but its root is still wrapped in a scene which is still the scene of that modal stage so next time openModal is called, the `owner` becomes the previous modal stage (because `currentWindow` will look at `root.scene.window` which points to the old modalstage).

This old modal stage is now the `owner` and because the owners position determines the starting position of the new modal stage it gets the placement wrong.

By removing the component as the root of the scene when closing the stage, it prevents that stage from being referenced by `currentWindow` in the future.
