### PR TITLE
 Do not try to force accessibility on `Parent.getChildren` via reflection

### DIFF
--- a/src/main/java/tornadofx/FX.kt
+++ b/src/main/java/tornadofx/FX.kt
@@ -694,14 +694,11 @@ fun EventTarget.getChildList(): MutableList<Node>? = when (this) {
 }
 
 @Suppress("UNCHECKED_CAST", "PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-private fun Parent.getChildrenReflectively(): MutableList<Node>? {
-    val getter = this.javaClass.findMethodByName("getChildren")
-    if (getter != null && java.util.List::class.java.isAssignableFrom(getter.returnType)) {
-        getter.isAccessible = true
-        return getter.invoke(this) as MutableList<Node>
-    }
-    return null
-}
+private fun Parent.getChildrenReflectively(): MutableList<Node>? = this.javaClass
+    .findMethodByName("getChildren")
+    ?.takeIf { java.util.List::class.java.isAssignableFrom(it.returnType) }
+    ?.takeIf { getter -> getter.canAccess(this) || getter.trySetAccessible() }
+    ?.let { getter -> getter.invoke(this) as MutableList<Node> }
 
 var Window.aboutToBeShown: Boolean
     get() = properties["tornadofx.aboutToBeShown"] == true

--- a/src/test/kotlin/tornadofx/testapps/TableViewCheckboxReflection.kt
+++ b/src/test/kotlin/tornadofx/testapps/TableViewCheckboxReflection.kt
@@ -1,0 +1,19 @@
+package tornadofx.testapps
+
+import javafx.beans.property.SimpleBooleanProperty
+import tornadofx.*
+
+class TableViewCheckboxApp : App(TableViewCheckbox::class)
+
+class Model {
+    val booleanProperty = SimpleBooleanProperty()
+}
+
+class TableViewCheckbox : View() {
+    val items = observableListOf(Model())
+
+    override val root = tableview(items) {
+        column("Checkbox", Model::booleanProperty)
+            .useCheckbox()
+    }
+}


### PR DESCRIPTION
Fixes edvin/tornadofx#1217, fixes edvin/tornadofx#1270, fixes edvin/tornadofx#1276.

See also: edvin/tornadofx@4b4f39f (this fix was introduced earlier, but then accidentally undone)